### PR TITLE
Fix the bugs in sgmm3bindnn/Makefile and src/MakeFile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ SHELL := /bin/bash
 SUBDIRS = base matrix util feat tree thread gmm transform sgmm \
           fstext hmm lm decoder lat kws cudamatrix nnet \
           bin fstbin gmmbin fgmmbin sgmmbin featbin \
-          nnetbin latbin sgmm2 sgmm2bin nnet2 nnet3 nnet3bin nnet2bin kwsbin \
+          nnetbin latbin sgmm2 sgmm2dnn sgmm2bindnn sgmm3dnn sgmm3bindnn nnet2 nnet3 nnet3bin nnet2bin kwsbin \
           ivector ivectorbin online2 online2bin lmbin
 
 MEMTESTDIRS = base matrix util feat tree thread gmm transform sgmm \

--- a/src/sgmm3bindnn/Makefile
+++ b/src/sgmm3bindnn/Makefile
@@ -18,7 +18,7 @@ TESTFILES =
 
 
 ADDLIBS =  ../decoder/kaldi-decoder.a ../lat/kaldi-lat.a ../feat/kaldi-feat.a \
-	../sgmm2dnn/kaldi-sgmm2.a ../transform/kaldi-transform.a ../gmm/kaldi-gmm.a \
+	../sgmm3dnn/kaldi-sgmm2.a ../transform/kaldi-transform.a ../gmm/kaldi-gmm.a \
 	../hmm/kaldi-hmm.a ../tree/kaldi-tree.a ../matrix/kaldi-matrix.a  \
 	../thread/kaldi-thread.a ../fstext/kaldi-fstext.a \
     ../util/kaldi-util.a ../base/kaldi-base.a 


### PR DESCRIPTION
Change the root-level makefile so that the sgmm2dnn and sgmm3dnn are included
Change the sgmm3bindnn makefile so that the library is sgmm3dnn
rather than sgmm2dnn
